### PR TITLE
Improve handling of context cancellation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+all: fmt lint test
+
+.PHONY: fmt
+fmt:
+	go mod tidy
+	gofumpt -s -w .
+	gofumports -w .
+
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+.PHONY: test
+test:
+	mkdir -p bin
+	go test -race -coverprofile=bin/cover.out ./...
+	go tool cover -html=bin/cover.out -o bin/cover.html

--- a/retry.go
+++ b/retry.go
@@ -63,9 +63,11 @@ func (r Retry) waitBackoffTime(ctx context.Context, attempt int) error {
 	if r.backoff == nil {
 		return ctx.Err()
 	}
+	return wait(ctx, r.backoff.Next(attempt))
+}
 
-	// Wait until the context is cancelled or until the backoff wait is over
-	waitCtx, cancel := context.WithTimeout(ctx, r.backoff.Next(attempt))
+func wait(ctx context.Context, duration time.Duration) error {
+	waitCtx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
 	select {

--- a/retry.go
+++ b/retry.go
@@ -64,6 +64,7 @@ func (r Retry) waitBackoffTime(ctx context.Context, attempt int) error {
 		return ctx.Err()
 	}
 
+	// Wait until the context is cancelled or until the backoff wait is over
 	waitCtx, cancel := context.WithTimeout(ctx, r.backoff.Next(attempt))
 	defer cancel()
 


### PR DESCRIPTION
The context was being checked before the function call + backoff. Therefore, two cases were not covered:
* a context cancellation happens right after the function `fn` starts -> the backoff sleep would have been executed anyway,
* a context cancellation happens during the backoff sleep -> the backoff sleep would have been carried out fully anyway.