### PR TITLE
Add retry policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ import (
 	"github.com/vthiery/retry"
 )
 
+var nonRetryableError = errors.New("a non-retryable error")
+
 func main() {
 	// Define the retry strategy, with 10 attempts and an exponential backoff
 	retry := retry.New(
@@ -41,6 +43,11 @@ func main() {
 				1*time.Second,        // maxWait
 				2*time.Millisecond,   // maxJitter
 			),
+		),
+		retry.WithPolicy(
+			func(err error) bool {
+				return !errors.Is(err, nonRetryableError)
+			},
 		),
 	)
 

--- a/retry.go
+++ b/retry.go
@@ -50,6 +50,7 @@ func (r *Retry) Do(ctx context.Context, fn func(context.Context) error) error {
 			if !r.policy(err) {
 				return fmt.Errorf("got a non-retryable error: %w", err)
 			}
+
 			attempt++
 			if r.exhaustedAttempts(attempt) {
 				return fmt.Errorf("all attempts have been exhausted, finished with error: %w", err)

--- a/retry.go
+++ b/retry.go
@@ -25,7 +25,7 @@ type Backoff interface {
 }
 
 // Policy describes the retry policy based on the error.
-// It should return true for retryable errors and false otherwise.
+// It must return true for retryable errors and false otherwise.
 type Policy func(err error) bool
 
 // NoAttemptsAllowedError is used to signal that no attempts are allowed.

--- a/retry.go
+++ b/retry.go
@@ -48,7 +48,7 @@ func (r *Retry) Do(ctx context.Context, fn func(context.Context) error) error {
 	for {
 		if err := fn(ctx); err != nil {
 			if !r.policy(err) {
-				return fmt.Errorf("got a non-retryable: %w", err)
+				return fmt.Errorf("got a non-retryable error: %w", err)
 			}
 			attempt++
 			if r.exhaustedAttempts(attempt) {

--- a/retry.go
+++ b/retry.go
@@ -8,6 +8,10 @@ import (
 
 // Retry allows to retry a function until the amount of attempts is exhausted,
 // using a backoff mechanism to wait between successive attempts.
+// By default, there retrier will:
+//     * attempts ad infinitum
+//     * not observe wait between successive attempts
+//     * retry on all errors
 type Retry struct {
 	maxAttempts *int
 	backoff     Backoff


### PR DESCRIPTION
The goal of this change is to allow the user to explicit for which errors the retry should occur or not. Otherwise, the user is forced to exhaust all the attempts (and possibly wait a significant amount of time) even when the errors returned by the inner function should not be retried.